### PR TITLE
Fix huggingface_hub / diffusers compatibility issues in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers==0.20.0
+diffusers==0.29.0
 transformers==4.33.1
 accelerate==0.22.0
 scipy


### PR DESCRIPTION
As mentioned in https://github.com/p1atdev/LECO/issues/44#issuecomment-2592104605, it is more future-proof to upgrade `diffusers` version rather than downgrading `huggingface_hub` to an old one. This will also fix the `cannot import name 'cached_download' from 'huggingface_hub'` issue without relying on outdated packages.